### PR TITLE
Change to adapt to new password creation and new certificate directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # defaults file for kibana
 kibana_config_backup: true
+kibana_manage_yaml: true
+elastic_ca_dir: /opt/es-ca

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
     backup: "{{ kibana_config_backup }}"
   notify:
     - Restart Kibana
+  when: kibana_manage_yaml | bool
 - name: start Kibana
   service:
     name: kibana

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -15,11 +15,17 @@
     owner: root
     group: kibana
     mode: 0750
+  tags:
+    - certificates
 - name: Fetch certificate from ca host to master
   fetch: src={{ elastic_ca_dir }}/{{ ansible_hostname }}.p12 dest=/tmp/ flat=yes
   delegate_to: "{{ elasticsearch_ca }}"
+  tags:
+    - certificates
 - name: Copy the certificate to actual node 
   copy: src=/tmp/{{ ansible_hostname }}.p12 dest=/etc/kibana/certs
+  tags:
+    - certificates
 - name: fetch Kibana password
   shell: grep "PASSWORD kibana " /usr/share/elasticsearch/initial_passwords | awk {' print $4 '}
   register: kibana_password
@@ -29,3 +35,5 @@
   shell: echo "" | openssl pkcs12 -in /etc/kibana/certs/{{ ansible_hostname }}.p12 -cacerts -nokeys -out /etc/kibana/certs/ca.crt -password stdin
   args:
     creates: /etc/kibana/certs/ca.crt
+  tags:
+    - certificates

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -16,12 +16,12 @@
     group: kibana
     mode: 0750
 - name: Fetch certificate from ca host to master
-  fetch: src=/usr/share/elasticsearch/{{ ansible_hostname }}.p12 dest=/tmp/ flat=yes
+  fetch: src={{ elastic_ca_dir }}/{{ ansible_hostname }}.p12 dest=/tmp/ flat=yes
   delegate_to: "{{ elasticsearch_ca }}"
 - name: Copy the certificate to actual node 
   copy: src=/tmp/{{ ansible_hostname }}.p12 dest=/etc/kibana/certs
 - name: fetch Kibana password
-  shell: grep "PASSWORD kibana" /usr/share/elasticsearch/initial_passwords | awk {' print $4 '}
+  shell: grep "PASSWORD kibana " /usr/share/elasticsearch/initial_passwords | awk {' print $4 '}
   register: kibana_password
   changed_when: false
   delegate_to: "{{ elasticsearch_ca }}"


### PR DESCRIPTION
These changes work with the other two roles to set up Kibana with security enabled.

We might need some more tests e.g. without security, as a standalone role etc., though before release.